### PR TITLE
Clear inode on destroy

### DIFF
--- a/src/kernel/inode.c
+++ b/src/kernel/inode.c
@@ -444,6 +444,8 @@ int inode_destroy(struct inode *inode) {
 
   read_inode(inode->index, &minix_inode);
   unmark_zmap(minix_inode.i_zone[0]);
+  memset(&minix_inode, 0, sizeof(struct minix2_inode));
+  write_inode(inode->index, &minix_inode);
 
   unmark_imap(inode->index);
   release_inode(inode);

--- a/src/test-kernel/inode.c
+++ b/src/test-kernel/inode.c
@@ -88,7 +88,7 @@ TEST(test_inode_create_3) {
   TEST_ASSERT(list_length(&inodes) == 2);
 }
 
-TEST(test_inode_destroy) {
+TEST(test_inode_destroy_0) {
   struct inode *inode;
 
   setup();
@@ -99,4 +99,22 @@ TEST(test_inode_destroy) {
 
   inode_destroy(inode);
   TEST_ASSERT(list_length(&inodes) == 0);
+}
+
+TEST(test_inode_destroy_1) {
+  struct inode *inode;
+  struct minix2_inode minix_inode;
+  inode_index index;
+
+  setup();
+
+  inode = inode_create(S_IFREG | 0755);
+  index = inode->index;
+
+  read_inode(index, &minix_inode);
+  TEST_ASSERT(minix_inode.i_mode != 0);
+
+  inode_destroy(inode);
+  read_inode(index, &minix_inode);
+  TEST_ASSERT(minix_inode.i_mode == 0);
 }

--- a/src/test-kernel/inode.t
+++ b/src/test-kernel/inode.t
@@ -37,4 +37,9 @@ TEST(test_inode_create_3);
 /*
 $shutdown
 */
-TEST(test_inode_destroy);
+TEST(test_inode_destroy_0);
+
+/*
+$shutdown
+*/
+TEST(test_inode_destroy_1);


### PR DESCRIPTION
Fixed following warnings of `fsck.mfs`:

```
$ fsck.mfs build/disk.img           

Checking zone map. 
Checking inode map. 
Checking inode list. 
mode inode 225 not cleared
mode inode 226 not cleared

blocksize =  4096        zonesize  =  4096

     213    Regular files
      11    Directories
       0    Block special files
       0    Character special files
   32544    Free inodes
       0    Named pipes
       0    Unix sockets
       0    Symbolic links
   10808    Free zones
```
