### PR TITLE
Added __aeabi_memclr

### DIFF
--- a/src/kernel/aeabi.c
+++ b/src/kernel/aeabi.c
@@ -25,6 +25,10 @@ void __aeabi_memcpy(void *dest, const void *src, size_t size) {
   memcpy(dest, src, size);
 }
 
+void __aeabi_memclr(void *dest, size_t n) {
+  memset(dest, 0, n);
+}
+
 void __aeabi_memclr8(void *dest, size_t n) {
   memset(dest, 0, n);
 }


### PR DESCRIPTION
Fix the following errors on clang 3.9.0.

```
lib/string.o: In function `test_strncpy':
../../src/test-kernel/lib/string.c:(.text+0x544): undefined reference to `__aeabi_memclr'
lib/string.o: In function `test_strcat':
../../src/test-kernel/lib/string.c:(.text+0x754): undefined reference to `__aeabi_memclr'
lib/string.o: In function `test_strncat':
../../src/test-kernel/lib/string.c:(.text+0x87c): undefined reference to `__aeabi_memclr'
collect2: error: ld returned 1 exit status
```